### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ccagent/


### PR DESCRIPTION
## Summary
Added a `.gitignore` file to exclude the `.ccagent/` directory from version control.

## Changes
- **Added `.gitignore`**: Created gitignore file to prevent tracking of the `.ccagent/` directory, which likely contains temporary files or build artifacts that should not be committed to the repository.

---
Generated with [Claude Control](https://claudecontrol.com) from this [slack thread](https://sideprojects-mw61570.slack.com/archives/C096LGC5PBN/p1754141320843169)