### PR TITLE
Add .gitignore for .ccagent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ccagent/


### PR DESCRIPTION
## Summary

Added `.gitignore` file to exclude the `.ccagent/` directory from version control, preventing temporary agent files from being tracked in the repository.

## Changes

- **Added `.gitignore`**: Created new gitignore file with entry to exclude `.ccagent/` directory
- **Repository cleanup**: Ensures agent-related temporary files and directories are not committed to version control

---
Generated with [Claude Control](https://claudecontrol.com) from this [slack thread](https://sideprojects-mw61570.slack.com/archives/C096LGC5PBN/p1754141534219989)