### PR TITLE
Add .gitignore for .ccagent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ccagent/


### PR DESCRIPTION
## Summary
Added `.gitignore` configuration to exclude the `.ccagent/` directory from version control.

## Changes
- Created `.gitignore` file with entry for `.ccagent/` directory
- Ensures ccagent-related temporary files and directories are not tracked in Git

---
Generated with [Claude Control](https://claudecontrol.com) from this [slack thread](https://sideprojects-mw61570.slack.com/archives/C096LGC5PBN/p1754142513370929)